### PR TITLE
Add tests for binding same port on Windows

### DIFF
--- a/test/socket.js
+++ b/test/socket.js
@@ -567,7 +567,6 @@ test('different socket binds to specific host but same port', async function (t)
   await b.close()
 })
 
-
 test('close twice', async function (t) {
   t.plan(1)
 

--- a/test/socket.js
+++ b/test/socket.js
@@ -529,6 +529,45 @@ test('bind while closing', function (t) {
   }
 })
 
+test('different socket binds to specific host but same port', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+  const b = u.createSocket()
+
+  a.bind(0, '127.0.0.1')
+
+  try {
+    b.bind(a.address().port, '0.0.0.0')
+  } catch (error) {
+    t.is(error.code, 'EADDRINUSE')
+  }
+
+  await a.close()
+  await b.close()
+})
+
+test('different socket binds to specific host but same port', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+  const b = u.createSocket()
+
+  a.bind()
+
+  try {
+    b.bind(a.address().port, '0.0.0.0')
+  } catch (error) {
+    t.is(error.code, 'EADDRINUSE')
+  }
+
+  await a.close()
+  await b.close()
+})
+
+
 test('close twice', async function (t) {
   t.plan(1)
 


### PR DESCRIPTION
The bind order doesn't affect which sockets receives the message, but it respects a host priority like this:
`127.0.0.1`
`0.0.0.0`
`::`

So if a `127.0.0.1` bind was set, then all messages will be sent to that one, and so on
