### PR TITLE
Return 0 for socket metrics before the socket is bound

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -44,18 +44,22 @@ module.exports = class UDXSocket extends events.EventEmitter {
   }
 
   get bytesTransmitted () {
+    if (this._inited !== true) return 0
     return Number(this._view64[binding.offsetof_udx_socket_t_bytes_out >> 3])
   }
 
   get packetsTransmitted () {
+    if (this._inited !== true) return 0
     return Number(this._view64[binding.offsetof_udx_socket_t_packets_out >> 3])
   }
 
   get bytesReceived () {
+    if (this._inited !== true) return 0
     return Number(this._view64[binding.offsetof_udx_socket_t_bytes_in >> 3])
   }
 
   get packetsReceived () {
+    if (this._inited !== true) return 0
     return Number(this._view64[binding.offsetof_udx_socket_t_packets_in >> 3])
   }
 

--- a/test/socket.js
+++ b/test/socket.js
@@ -743,3 +743,14 @@ test('set send buffer size', async function (t) {
 
   await a.close()
 })
+
+test('UDX - socket stats 0 before bind is called', async function (t) {
+  const a = new UDX()
+
+  const aSocket = a.createSocket()
+
+  t.is(aSocket.bytesTransmitted, 0)
+  t.is(aSocket.packetsTransmitted, 0)
+  t.is(aSocket.bytesReceived, 0)
+  t.is(aSocket.packetsReceived, 0)
+})


### PR DESCRIPTION
Previous behaviour was undefined (it just returned whichever number was represented by the ~random bytes inside the buffer)