### PR TITLE
Expose rto, fast_recovery and retransmit counts

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -1018,6 +1018,9 @@ NAPI_INIT() {
   NAPI_EXPORT_OFFSETOF(udx_stream_t, packets_in)
   NAPI_EXPORT_OFFSETOF(udx_stream_t, bytes_out)
   NAPI_EXPORT_OFFSETOF(udx_stream_t, packets_out)
+  NAPI_EXPORT_OFFSETOF(udx_stream_t, retransmit_count)
+  NAPI_EXPORT_OFFSETOF(udx_stream_t, fast_recovery_count)
+  NAPI_EXPORT_OFFSETOF(udx_stream_t, rto_count)
 
   NAPI_EXPORT_OFFSETOF(udx_socket_t, bytes_in)
   NAPI_EXPORT_OFFSETOF(udx_socket_t, packets_in)

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -80,17 +80,12 @@ module.exports = class UDXStream extends streamx.Duplex {
     return this._view[binding.offsetof_udx_stream_t_cwnd >> 2]
   }
 
-  get retransmitCount () {
+  get retransmits () {
     return this._view[binding.offsetof_udx_stream_t_retransmit_count >> 2] & 0xffff
   }
 
-  get fastRecoveryCount () {
+  get fastRecoveries () {
     return this._view[binding.offsetof_udx_stream_t_fast_recovery_count >> 2] & 0xffff
-  }
-
-  get rtoCount () {
-    // rto = Retransmission timeout
-    return this._view[binding.offsetof_udx_stream_t_rto_count >> 2] & 0xffff
   }
 
   get inflight () {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -80,6 +80,19 @@ module.exports = class UDXStream extends streamx.Duplex {
     return this._view[binding.offsetof_udx_stream_t_cwnd >> 2]
   }
 
+  get retransmitCount () {
+    return this._view[binding.offsetof_udx_stream_t_retransmit_count >> 2] & 0xffff
+  }
+
+  get fastRecoveryCount () {
+    return this._view[binding.offsetof_udx_stream_t_fast_recovery_count >> 2] & 0xffff
+  }
+
+  get rtoCount () {
+    // rto = Retransmission timeout
+    return this._view[binding.offsetof_udx_stream_t_rto_count >> 2] & 0xffff
+  }
+
   get inflight () {
     return this._view[binding.offsetof_udx_stream_t_inflight >> 2]
   }

--- a/test/stream.js
+++ b/test/stream.js
@@ -867,9 +867,8 @@ test('UDX - basic stats', async function (t) {
 
   // these seem to be consistently 1 at the start, so we don't check for 0
   // but just that they exist and are a number
-  t.is(a.retransmitCount >= 0, true, 'sanity check: it is a number')
-  t.is(a.fastRecoveryCount >= 0, true, 'sanity check: it is a number')
-  t.is(a.rtoCount >= 0, true, 'sanity check: it is a number')
+  t.is(a.retransmits >= 0, true, 'sanity check: it is a number')
+  t.is(a.fastRecoveries >= 0, true, 'sanity check: it is a number')
 
   let aNrDataEvents = 0
   a.on('data', function (data) {

--- a/test/stream.js
+++ b/test/stream.js
@@ -865,6 +865,12 @@ test('UDX - basic stats', async function (t) {
   t.is(aUdx.bytesReceived, 0, 'sanity check: init 0')
   t.is(aUdx.packetsReceived, 0, 'sanity check: init 0')
 
+  // these seem to be consistently 1 at the start, so we don't check for 0
+  // but just that they exist and are a number
+  t.is(a.retransmitCount >= 0, true, 'sanity check: it is a number')
+  t.is(a.fastRecoveryCount >= 0, true, 'sanity check: it is a number')
+  t.is(a.rtoCount >= 0, true, 'sanity check: it is a number')
+
   let aNrDataEvents = 0
   a.on('data', function (data) {
     if (++aNrDataEvents === 1) {


### PR DESCRIPTION
Please review with some care (I don't have experience with C bindings).

In particular, check that my conversion from 16-bit ints makes sense. I copied the MTU approach, since that's also a uint16, but I was a bit surprised that the counts all show up as 1 in the test (probably expected, but good to sanity check)