### PR TITLE
Fix/binding offsets, adds back rtoCount

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -846,10 +846,10 @@ NAPI_METHOD(udx_napi_stream_writev) {
   NAPI_RETURN_UINT32(err);
 }
 
-NAPI_METHOD(udx_napi_stream_write_sizeof) {
+NAPI_METHOD(udx_napi_stream_write_sizeof){
   NAPI_ARGV(1)
-  NAPI_ARGV_UINT32(bufs, 0)
-  NAPI_RETURN_UINT32(udx_stream_write_sizeof(bufs))
+    NAPI_ARGV_UINT32(bufs, 0)
+      NAPI_RETURN_UINT32(udx_stream_write_sizeof(bufs))
 }
 
 NAPI_METHOD(udx_napi_stream_write_end) {
@@ -1018,6 +1018,7 @@ NAPI_INIT() {
   NAPI_EXPORT_OFFSETOF(udx_stream_t, packets_in)
   NAPI_EXPORT_OFFSETOF(udx_stream_t, bytes_out)
   NAPI_EXPORT_OFFSETOF(udx_stream_t, packets_out)
+  NAPI_EXPORT_OFFSETOF(udx_stream_t, rto_count)
   NAPI_EXPORT_OFFSETOF(udx_stream_t, retransmit_count)
   NAPI_EXPORT_OFFSETOF(udx_stream_t, fast_recovery_count)
 

--- a/binding.c
+++ b/binding.c
@@ -846,7 +846,7 @@ NAPI_METHOD(udx_napi_stream_writev) {
   NAPI_RETURN_UINT32(err);
 }
 
-NAPI_METHOD(udx_napi_stream_write_sizeof){
+NAPI_METHOD(udx_napi_stream_write_sizeof) {
   NAPI_ARGV(1)
   NAPI_ARGV_UINT32(bufs, 0)
   NAPI_RETURN_UINT32(udx_stream_write_sizeof(bufs))

--- a/binding.c
+++ b/binding.c
@@ -848,8 +848,8 @@ NAPI_METHOD(udx_napi_stream_writev) {
 
 NAPI_METHOD(udx_napi_stream_write_sizeof){
   NAPI_ARGV(1)
-    NAPI_ARGV_UINT32(bufs, 0)
-      NAPI_RETURN_UINT32(udx_stream_write_sizeof(bufs))
+  NAPI_ARGV_UINT32(bufs, 0)
+  NAPI_RETURN_UINT32(udx_stream_write_sizeof(bufs))
 }
 
 NAPI_METHOD(udx_napi_stream_write_end) {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -81,7 +81,7 @@ module.exports = class UDXStream extends streamx.Duplex {
     return this._view[binding.offsetof_udx_stream_t_cwnd >> 2]
   }
 
-  get rtoCount() {
+  get rtoCount () {
     return this._view16[binding.offsetof_udx_stream_t_rto_count >> 1]
   }
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -15,6 +15,7 @@ module.exports = class UDXStream extends streamx.Duplex {
 
     this._handle = b4a.allocUnsafe(binding.sizeof_udx_napi_stream_t)
     this._view = new Uint32Array(this._handle.buffer, this._handle.byteOffset, this._handle.byteLength >> 2)
+    this._view16 = new Uint16Array(this._handle.buffer, this._handle.byteOffset, this._handle.byteLength >> 1)
     this._view64 = new BigUint64Array(this._handle.buffer, this._handle.byteOffset, this._handle.byteLength >> 3)
 
     this._wreqs = []
@@ -69,7 +70,7 @@ module.exports = class UDXStream extends streamx.Duplex {
   }
 
   get mtu () {
-    return this._view[binding.offsetof_udx_stream_t_mtu >> 2] & 0xffff
+    return this._view16[binding.offsetof_udx_stream_t_mtu >> 1]
   }
 
   get rtt () {
@@ -80,12 +81,16 @@ module.exports = class UDXStream extends streamx.Duplex {
     return this._view[binding.offsetof_udx_stream_t_cwnd >> 2]
   }
 
+  get rtoCount() {
+    return this._view16[binding.offsetof_udx_stream_t_rto_count >> 1]
+  }
+
   get retransmits () {
-    return this._view[binding.offsetof_udx_stream_t_retransmit_count >> 2] & 0xffff
+    return this._view16[binding.offsetof_udx_stream_t_retransmit_count >> 1]
   }
 
   get fastRecoveries () {
-    return this._view[binding.offsetof_udx_stream_t_fast_recovery_count >> 2] & 0xffff
+    return this._view16[binding.offsetof_udx_stream_t_fast_recovery_count >> 1]
   }
 
   get inflight () {

--- a/test/stream.js
+++ b/test/stream.js
@@ -865,10 +865,9 @@ test('UDX - basic stats', async function (t) {
   t.is(aUdx.bytesReceived, 0, 'sanity check: init 0')
   t.is(aUdx.packetsReceived, 0, 'sanity check: init 0')
 
-  // these seem to be consistently 1 at the start, so we don't check for 0
-  // but just that they exist and are a number
-  t.is(a.retransmits >= 0, true, 'sanity check: it is a number')
-  t.is(a.fastRecoveries >= 0, true, 'sanity check: it is a number')
+  t.is(a.retransmits, 0, 'initialized to zero')
+  t.is(a.rtoCount, 0, 'initialized to zero')
+  t.is(a.fastRecoveries, 0, 'initialized to zero')
 
   let aNrDataEvents = 0
   a.on('data', function (data) {


### PR DESCRIPTION
- Uses a Uint16Array for extracting the 2-byte fields
- adds rtoCount - this field counts the number of times a stream's retransmission timer has fired.