### PR TITLE
Use system LLVM and work around compiler bug instead

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -60,15 +60,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
-    - run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 20
-      if: ${{ matrix.platform == 'linux' }}
-    - run: choco upgrade llvm
-      if: ${{ matrix.platform == 'win32' }}
-    - run: brew install llvm
-      if: ${{ matrix.platform == 'darwin' }}
     - run: npm install -g bare-make
     - run: npm install
     - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
-    - run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 20
-      if: ${{ matrix.platform == 'linux' }}
-    - run: choco upgrade llvm
-      if: ${{ matrix.platform == 'win32' }}
-    - run: brew install llvm
-      if: ${{ matrix.platform == 'darwin' }}
     - run: npm install -g bare-runtime bare-make
     - run: npm install
     - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}

--- a/binding.cc
+++ b/binding.cc
@@ -205,7 +205,7 @@ on_udx_message (udx_socket_t *self, ssize_t read_len, const uv_buf_t *buf, const
   ip_str = ip;
 
   js_typedarray_span_t<> res;
-  err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t, int64_t, int, std::string, int>(
+  err = js_call_function_with_checkpoint<js_type_options_t{}, js_typedarray_span_t<>, js_receiver_t, int64_t, int, std::string, int>(
     env,
     callback,
     ctx,
@@ -237,7 +237,7 @@ on_udx_message (udx_socket_t *self, ssize_t read_len, const uv_buf_t *buf, const
       err = js_get_reference_value(env, n->realloc_message, callback);
       assert(err == 0);
 
-      err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
+      err = js_call_function_with_checkpoint<js_type_options_t{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
       assert(err == 0);
 
       n->udx->read_buf = res.data();
@@ -394,7 +394,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   assert(err == 0);
 
   js_typedarray_span_t<> res;
-  err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t, uint32_t>(env, callback, ctx, uint32_t(read), res);
+  err = js_call_function_with_checkpoint<js_type_options_t{}, js_typedarray_span_t<>, js_receiver_t, uint32_t>(env, callback, ctx, uint32_t(read), res);
 
   if (err == 0) {
     n->read_buf = res.data();
@@ -415,7 +415,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
       err = js_get_reference_value(env, n->realloc_data, callback);
       assert(err == 0);
 
-      err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
+      err = js_call_function_with_checkpoint<js_type_options_t{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
       assert(err == 0);
 
       n->read_buf = res.data();
@@ -545,7 +545,7 @@ on_udx_stream_recv (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   assert(err == 0);
 
   js_typedarray_span_t<> res;
-  err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t, uint32_t>(env, callback, ctx, uint32_t(read_len), res);
+  err = js_call_function_with_checkpoint<js_type_options_t{}, js_typedarray_span_t<>, js_receiver_t, uint32_t>(env, callback, ctx, uint32_t(read_len), res);
 
   if (err == 0) {
     n->udx->read_buf = res.data();
@@ -565,7 +565,7 @@ on_udx_stream_recv (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
       err = js_get_reference_value(env, n->realloc_message, callback);
       assert(err == 0);
 
-      err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
+      err = js_call_function_with_checkpoint<js_type_options_t{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
       assert(err == 0);
 
       n->udx->read_buf = res.data();
@@ -672,7 +672,7 @@ on_udx_stream_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct
   err = js_get_reference_value(env, s->ctx, socket_ctx);
   assert(err == 0);
 
-  err = js_call_function_with_checkpoint<{}, uint32_t, js_receiver_t, js_receiver_t, uint32_t, std::string, uint32_t>(
+  err = js_call_function_with_checkpoint<js_type_options_t{}, uint32_t, js_receiver_t, js_receiver_t, uint32_t, std::string, uint32_t>(
     env,
     callback,
     ctx,

--- a/binding.cc
+++ b/binding.cc
@@ -205,8 +205,7 @@ on_udx_message (udx_socket_t *self, ssize_t read_len, const uv_buf_t *buf, const
   ip_str = ip;
 
   js_typedarray_span_t<> res;
-
-  err = js_call_function_with_checkpoint(
+  err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t, int64_t, int, std::string, int>(
     env,
     callback,
     ctx,
@@ -238,7 +237,7 @@ on_udx_message (udx_socket_t *self, ssize_t read_len, const uv_buf_t *buf, const
       err = js_get_reference_value(env, n->realloc_message, callback);
       assert(err == 0);
 
-      err = js_call_function_with_checkpoint(env, callback, ctx, res);
+      err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
       assert(err == 0);
 
       n->udx->read_buf = res.data();
@@ -328,7 +327,6 @@ on_udx_stream_end (udx_stream_t *stream) {
   assert(err == 0);
 
   cb_stream_end_t callback;
-
   err = js_get_reference_value(env, n->on_end, callback);
   assert(err == 0);
 
@@ -396,7 +394,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   assert(err == 0);
 
   js_typedarray_span_t<> res;
-  err = js_call_function_with_checkpoint(env, callback, ctx, uint32_t(read), res);
+  err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t, uint32_t>(env, callback, ctx, uint32_t(read), res);
 
   if (err == 0) {
     n->read_buf = res.data();
@@ -417,7 +415,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
       err = js_get_reference_value(env, n->realloc_data, callback);
       assert(err == 0);
 
-      err = js_call_function_with_checkpoint(env, callback, ctx, res);
+      err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
       assert(err == 0);
 
       n->read_buf = res.data();
@@ -547,7 +545,7 @@ on_udx_stream_recv (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   assert(err == 0);
 
   js_typedarray_span_t<> res;
-  err = js_call_function_with_checkpoint(env, callback, ctx, uint32_t(read_len), res);
+  err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t, uint32_t>(env, callback, ctx, uint32_t(read_len), res);
 
   if (err == 0) {
     n->udx->read_buf = res.data();
@@ -567,7 +565,7 @@ on_udx_stream_recv (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
       err = js_get_reference_value(env, n->realloc_message, callback);
       assert(err == 0);
 
-      err = js_call_function_with_checkpoint(env, callback, ctx, res);
+      err = js_call_function_with_checkpoint<{}, js_typedarray_span_t<>, js_receiver_t>(env, callback, ctx, res);
       assert(err == 0);
 
       n->udx->read_buf = res.data();
@@ -674,7 +672,7 @@ on_udx_stream_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct
   err = js_get_reference_value(env, s->ctx, socket_ctx);
   assert(err == 0);
 
-  err = js_call_function_with_checkpoint(
+  err = js_call_function_with_checkpoint<{}, uint32_t, js_receiver_t, js_receiver_t, uint32_t, std::string, uint32_t>(
     env,
     callback,
     ctx,


### PR DESCRIPTION
Android prebuilds are borked as well and we can't really control the exact toolchain the Android SDK uses.