### PR TITLE
fix: defer finish event until write-end is acknowledged by peer

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -20,7 +20,7 @@ using cb_socket_realloc_message_t = js_function_t<js_typedarray_span_t<>, js_rec
 using cb_stream_end_t = js_function_t<void, js_receiver_t, uint32_t>;
 using cb_stream_data_t = js_function_t<js_typedarray_span_t<>, js_receiver_t, uint32_t>;
 using cb_stream_drain_t = js_function_t<void, js_receiver_t>;
-using cb_stream_ack_t = js_function_t<void, js_receiver_t, uint32_t>;
+using cb_stream_ack_t = js_function_t<void, js_receiver_t, uint32_t, int32_t>;
 using cb_stream_send_t = js_function_t<void, js_receiver_t, int32_t, int32_t>;
 using cb_stream_message_t = js_function_t<js_typedarray_span_t<>, js_receiver_t, uint32_t>;
 using cb_stream_realloc_data_t = js_function_t<js_typedarray_span_t<>, js_receiver_t>;
@@ -480,7 +480,7 @@ on_udx_stream_ack (udx_stream_write_t *req, int status, int unordered) {
 
   auto offset = reinterpret_cast<uintptr_t>(req->data);
 
-  err = js_call_function_with_checkpoint(env, callback, ctx, uint32_t(offset));
+  err = js_call_function_with_checkpoint(env, callback, ctx, uint32_t(offset), status);
   assert(err == 0);
 
   err = js_close_handle_scope(env, scope);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -44,6 +44,7 @@ module.exports = class UDXStream extends streamx.Duplex {
     this._reallocData()
 
     this._onwrite = null
+    this._onfinal = null
     this._ondestroy = null
     this._firewall = opts.firewall || firewallAll
 
@@ -349,20 +350,25 @@ module.exports = class UDXStream extends streamx.Duplex {
     const id = this._allocWrite(1)
     const req = this._wreqs[id]
 
-    req.flush = this._flushes
+    req.flush = this._flushing
     req.buffer = b4a.allocUnsafe(0)
+    req.onfinish = true
 
-    const drained =
-      binding.udx_napi_stream_write_end(this._handle, req.handle, id, req.buffer) !== 0
+    this._onfinal = cb
 
-    if (drained) cb(null)
-    else this._onwrite = cb
+    binding.udx_napi_stream_write_end(this._handle, req.handle, id, req.buffer)
   }
 
   _predestroy() {
     if (!this._closed) binding.udx_napi_stream_destroy(this._handle)
     this._closed = true
     this._writeContinue(null)
+
+    if (this._onfinal !== null) {
+      const cb = this._onfinal
+      this._onfinal = null
+      cb(null)
+    }
   }
 
   _destroy(cb) {
@@ -396,13 +402,36 @@ module.exports = class UDXStream extends streamx.Duplex {
     }
   }
 
-  _onack(id) {
+  _onack(id, status) {
     const req = this._wreqs[id]
 
+    const onfinish = req.onfinish === true
+
     req.buffers = req.buffer = null
+    req.onfinish = false
     this._wfree.push(id)
 
+    if (status < 0) {
+      if (this._flushes.length > 0) {
+        while (this._flushes.length > 0) this._flushes.shift().resolve(false)
+      }
+
+      if (onfinish && this._onfinal !== null) {
+        const cb = this._onfinal
+        this._onfinal = null
+        cb(customError('Stream write failed (ack)', 'ERR_STREAM_WRITE_ACK'))
+      }
+
+      return
+    }
+
     if (this._flushes.length > 0) this._flushAck(req.flush)
+
+    if (onfinish && this._onfinal !== null) {
+      const cb = this._onfinal
+      this._onfinal = null
+      cb(null)
+    }
 
     // gc the free list
     if (this._wfree.length >= 64 && this._wfree.length === this._wreqs.length) {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -419,7 +419,7 @@ module.exports = class UDXStream extends streamx.Duplex {
       if (onfinish && this._onfinal !== null) {
         const cb = this._onfinal
         this._onfinal = null
-        cb(customError('Stream write failed (ack)', 'ERR_STREAM_WRITE_ACK'))
+        cb(customError('Stream write failed (ack, status ' + status + ')', 'ERR_STREAM_WRITE_ACK'))
       }
 
       return

--- a/test/stream.js
+++ b/test/stream.js
@@ -938,3 +938,46 @@ test('UDX - basic stats', async function (t) {
     `udx socket same packets in as the single stream (${aSocket.packetsReceived})`
   )
 })
+
+test('destroy after finish delivers all packets to peer (hyperdht#232)', async function (t) {
+  t.plan(4)
+
+  const [a, b] = makeTwoStreams(t)
+
+  a.on('error', (err) => t.fail('a errored: ' + err.message))
+  b.on('error', (err) => t.fail('b errored: ' + err.message))
+
+  t.teardown(() => {
+    a.destroy()
+    b.destroy()
+  })
+
+  const packets = [
+    b4a.alloc(65536, 1),
+    b4a.alloc(65536, 2),
+    b4a.alloc(65536, 3)
+  ]
+
+  for (const pkt of packets) a.write(pkt)
+
+  a.end()
+
+  a.once('finish', function () {
+    a.destroy()
+  })
+
+  const received = []
+
+  b.on('data', function (data) {
+    received.push(b4a.from(data))
+  })
+
+  b.on('end', function () {
+    const all = b4a.concat(received)
+    t.is(all.length, 3 * 65536, 'peer received all bytes from 3 packets')
+    t.is(all[0], 1, 'first packet intact at start')
+    t.is(all[65536], 2, 'second packet intact at offset 65536')
+    t.is(all[2 * 65536], 3, 'last packet intact at offset 131072')
+    b.end()
+  })
+})

--- a/test/stream.js
+++ b/test/stream.js
@@ -960,11 +960,11 @@ test('destroy after finish delivers all packets to peer (hyperdht#232)', async f
 
   for (const pkt of packets) a.write(pkt)
 
-  a.end()
-
   a.once('finish', function () {
     a.destroy()
   })
+
+  a.end()
 
   const received = []
 


### PR DESCRIPTION
## Summary

Fixes the issue described in https://github.com/holepunchto/hyperdht/issues/232 where destroying a stream after `finish` causes `ECONNRESET` on the peer and drops in-flight packets.

**Root cause:** `_final()` called its callback as soon as the write buffer drained (data handed to the C layer), not when the peer actually ACK'd the packets. This meant `finish` fired prematurely — a subsequent `destroy()` would kill the C stream while data was still in-flight.

**Additionally:** the ACK callback in `binding.cc` was not propagating the `status` parameter to JavaScript, so cancelled/failed ACKs (e.g. after destroy) were silently treated as successful.

### Changes

- **`binding.cc`**: Widen the ACK callback signature to pass `status` (success/failure) from C to JS
- **`lib/stream.js`**:
  - `_final()`: Store callback in `this._onfinal` instead of calling it immediately; mark the write-end request with `req.onfinish = true`
  - `_onack()`: Accept `status` param; on success, call `_onfinal`; on failure (`status < 0`), resolve pending flushes as `false` and call `_onfinal` with an error
  - `_predestroy()`: Release `_onfinal` if stream is destroyed before ACK arrives (safety net to prevent streamx from hanging)
- **`test/stream.js`**: Add regression test that writes 3×64KB packets, calls `end()`, destroys on `finish`, and verifies the peer receives all packets

### Before this fix
```
client: write(1) write(2) write(3) end()
client: finish ← fires immediately (buffer drained)
client: destroy() ← kills C stream
server: ECONNRESET, packets 2,3 lost
```

### After this fix
```
client: write(1) write(2) write(3) end()
client: ... waiting for ACK ...
server: receives all packets + end
client: finish ← fires after peer ACK
client: destroy() ← safe, data already delivered
```

## Test plan

- [ ] `npm test` passes (requires native rebuild for binding.cc change)
- [ ] New test `destroy after finish delivers all packets to peer` passes
- [ ] Existing stream tests still pass (no regression on drain/flush behavior)