### PR TITLE
1.21.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(target MATCHES "win32")
   add_compile_options(/MT$<$<CONFIG:Debug>:d>)
 endif()
 
-fetch_package("github:holepunchto/libudx#66c9fa6")
+fetch_package("github:holepunchto/libudx#a9af5de")
 fetch_package("github:holepunchto/libjstl#098664c")
 
 add_bare_module(udx_native_bare)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udx-native",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "udx is reliable, multiplexed, and congestion-controlled streams over udp",
   "main": "lib/udx.js",
   "files": [


### PR DESCRIPTION
Bumps `libudx` to `a9af5de` which includes:

- refreshing ACK & RWND on retransmit
- ttl refactor to send slow path packets with custom ttl via the check callback simplifying the packet queue