### PR TITLE
Update `libjstl`, `bare-compat-napi` & `libudx`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(target MATCHES "win32")
 endif()
 
 fetch_package("github:holepunchto/libudx#01d6630")
-fetch_package("github:holepunchto/libjstl#098664c")
+fetch_package("github:holepunchto/libjstl#7e31e67")
 
 add_bare_module(udx_native_bare)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(target MATCHES "win32")
   add_compile_options(/MT$<$<CONFIG:Debug>:d>)
 endif()
 
-fetch_package("github:holepunchto/libudx#a9af5de")
+fetch_package("github:holepunchto/libudx#01d6630")
 fetch_package("github:holepunchto/libjstl#098664c")
 
 add_bare_module(udx_native_bare)

--- a/binding.cc
+++ b/binding.cc
@@ -1546,7 +1546,7 @@ udx_napi_lookup (
   self->udx = udx;
 
   std::string host;
-  err = js_get_value_string(env, host_str, host);
+  err = js_get_value(env, host_str, host);
   assert(err == 0);
 
   udx_lookup_t *lookup = &self->handle;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "streamx": "^2.22.0"
   },
   "devDependencies": {
-    "bare-compat-napi": "^1.3.0",
+    "bare-compat-napi": "^1.4.1",
     "brittle": "^3.1.0",
     "cmake-bare": "^1.1.10",
     "cmake-fetch": "^1.0.1",


### PR DESCRIPTION
`libudx` bump removes `ssthresh`
Needs to wait on the following for merge:
- https://github.com/holepunchto/bare-compat-napi/pull/6